### PR TITLE
Feat: search_nearest_neighbors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ KDNODE_TARGET = ./_kdnode$(PYTHON_SUF)
 KDTREE_SRC = $(SRC_DIR)/KDTree.cpp
 KDTREE_TARGET = ./_kdtree$(PYTHON_SUF)
 
-.PHONY: test clean
+.PHONY: all test clean
+
+all: $(POINT_TARGET) $(KDNODE_TARGET) $(KDTREE_TARGET)
 
 test: $(POINT_TARGET) $(KDNODE_TARGET) $(KDTREE_TARGET)
 	python3 -m pytest -vv

--- a/include/BoundedPriorityQueue.hpp
+++ b/include/BoundedPriorityQueue.hpp
@@ -4,16 +4,14 @@
 
 struct PairComparator{
     bool operator()(const std::pair<double, Point> &p1, const std::pair<double, Point> &p2){
-        return p1.first > p2.first;
+        return p1.first < p2.first;
     }
 };
 
 class BoundedPriorityQueue{
     private:
-        std::vector<std::pair<double, Point>> items;
-        std::priority_queue<std::pair<double, Point>, std::vector<std::pair<double, Point>>, PairComparator> pq;
+        std::vector<std::pair<double, Point>> pq;
         size_t capacity = 0;
-        size_t size = 0;
 
     public:
         /*
@@ -28,20 +26,24 @@ class BoundedPriorityQueue{
          * Getter
          */
 
-        size_t get_size(){
-            return size;
-        }
-
         size_t get_capacity(){
             return capacity;
         }
 
-        std::vector<std::pair<double, Point>> get_items(){
-            return items;
+        size_t get_size(){
+            return pq.size();
         }
 
         double max_priority(){
-            return pq.top().first;
+            return pq.front().first;
+        }
+
+        std::vector<Point> get_points(){
+            std::vector<Point> points;
+            for(auto const &pair : pq){
+                points.push_back(pair.second);
+            }
+            return points;
         }
 
         /*
@@ -49,15 +51,16 @@ class BoundedPriorityQueue{
          */
 
         void push(double distance, Point const &point){
-            if(size < capacity){
-                items.push_back(std::make_pair(distance, point));
-                pq.push(std::make_pair(distance, point));
-                size++;
+            if(pq.size() < capacity){
+                pq.push_back(std::make_pair(distance, point));
+                std::push_heap(pq.begin(), pq.end(), PairComparator());
             }
             else{
-                if(distance < pq.top().first){
-                    pq.pop();
-                    pq.push(std::make_pair(distance, point));
+                if(distance < pq.front().first){
+                    std::pop_heap(pq.begin(), pq.end(), PairComparator());
+                    pq.pop_back();
+                    pq.push_back(std::make_pair(distance, point));
+                    std::push_heap(pq.begin(), pq.end(), PairComparator());
                 }
             }
         }

--- a/include/KDNode.hpp
+++ b/include/KDNode.hpp
@@ -103,4 +103,12 @@ class KDNode{
         void set_axis(size_t axis){
             this->axis = axis;
         }
+
+        /*
+         * Operations
+         */
+
+        bool is_leaf(){
+            return this->left == nullptr && this->right == nullptr;
+        }
 };

--- a/include/KDTree.hpp
+++ b/include/KDTree.hpp
@@ -1,6 +1,8 @@
 # pragma once
 
-#include <KDNode.hpp>
+#include "BoundedPriorityQueue.hpp"
+#include "KDNode.hpp"
+
 #include <vector>
 #include <algorithm>
 
@@ -58,8 +60,16 @@ class KDTree{
         }
 
         /*
-         * Functionality of KDTree
+         * Tree Operations
          */
+        
         void insert_node(Point point);
         bool delete_node(Point point);
+
+        /*
+         * Search Operations
+         */
+
+        std::vector<Point> search_nearest_neighbors(Point point, size_t k);
+        void search_nearest_neighbors_recursive(Point point, std::shared_ptr<KDNode> current, BoundedPriorityQueue &bpq, size_t k);
 };

--- a/include/Point.hpp
+++ b/include/Point.hpp
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <vector>
+#include <stdexcept>
+#include <cmath>
 
 class Point{
     private:
@@ -104,7 +106,29 @@ class Point{
             return this->dim;
         }
 
-        double* get_coords() const{
-            return this->coords;
+        std::vector<double> get_coords() const{
+            std::vector<double> coords;
+            for(std::size_t i = 0; i < this->dim; i++){
+                coords.push_back(this->coords[i]);
+            }
+            return coords;
         }
 };
+
+/*
+ * Distance between two points
+ */
+
+double point_distance(Point const &p1, Point const &p2){
+    if(p1.get_dim() != p2.get_dim()){
+        throw std::invalid_argument("Points must have the same dimension");
+    }
+
+    double sum = 0;
+
+    for(std::size_t i = 0; i < p1.get_dim(); i++){
+        sum += (p1[i] - p2[i]) * (p1[i] - p2[i]);
+    }
+
+    return sqrt(sum);
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 iniconfig==2.0.0
+numpy==1.26.4
 packaging==24.0
+parameterized==0.9.0
 pluggy==1.5.0
 pybind11==2.12.0
 pytest==8.2.1
+scipy==1.13.1

--- a/src/KDNode.cpp
+++ b/src/KDNode.cpp
@@ -15,5 +15,6 @@ PYBIND11_MODULE(_kdnode, m) {
         .def_property("point", &KDNode::get_point, &KDNode::set_point)
         .def_property("left", &KDNode::get_left, &KDNode::set_left)
         .def_property("right", &KDNode::get_right, &KDNode::set_right)
-        .def_property("axis", &KDNode::get_axis, &KDNode::set_axis);
+        .def_property("axis", &KDNode::get_axis, &KDNode::set_axis)
+        .def_property_readonly("is_leaf", &KDNode::is_leaf);
 }

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -11,5 +11,7 @@ PYBIND11_MODULE(_point, m) {
         .def(pybind11::init<>())
         .def("__getitem__", [](Point &p, size_t i) { return p[i]; })
         .def("__eq__", &Point::operator==)
-        .def_property_readonly("dim", &Point::get_dim);
+        .def_property_readonly("dim", &Point::get_dim)
+        .def_property_readonly("coords", &Point::get_coords);
+    m.def("point_distance", &point_distance);
 }


### PR DESCRIPTION
### Feat
- `search_nearest_neighbors` implementation with `BoundedPriorityQueue`
- searching for `k` nearest neighbors with Euclidean distance

### Test
- test with `double` user-defined points ([0, 0, 0], [1, 1, 1], ...)
- test with `double` randomly generated points
- with different `num_nodes` and `dimensions`